### PR TITLE
feat: add custom webhook payload and support to Laravel 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,22 @@ You can customise the polling interval for the `Webhook-Server` by publishing th
     "event": "created",  // <== Type of Event
     "module": "Testing", // <== Module that were the event happend
     "triggered_at": "2023-01-18T05:07:37.748031Z", // <== Based on the Date and time the Event happen
-    "data": { // <== Actual information depending on what you selected "Summary or All"
+    "data": { // <== Actual information depending on what you selected "Summary, All or Custom"
       "id": 34,
       "created_at": "2023-01-18T05:07:37.000000Z"
     }
   }
 ]
+```
+for custom option you need to create toWebhookPayload method in your models
+
+```
+public function toWebhookPayload()
+{
+    return [
+        'customAttribute' => $this->yourAttribute
+    ];
+}
 ```
 
 ## Testing

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         }
     ],
     "require": {
-        "php": "^8.0 || ^8.1",
+        "php": "^8.0 || ^8.1 || ^8.2",
         "filament/filament": "^2.0",
-        "illuminate/contracts": "^9.0",
+        "illuminate/contracts": "^9.0 || ^10.0",
         "spatie/laravel-model-info": "^1.4",
         "spatie/laravel-package-tools": "^1.13.5",
         "spatie/laravel-webhook-server": "^3.4"
@@ -26,14 +26,14 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",
         "laravel/pint": "^1.4",
-        "nunomaduro/collision": "^6.0",
+        "nunomaduro/collision": "^6.0 || ^7.0",
         "orchestra/testbench": "^7.0",
         "pestphp/pest": "^1.22",
         "pestphp/pest-plugin-laravel": "^1.1",
         "pestphp/pest-plugin-livewire": "^1.0",
         "pestphp/pest-plugin-parallel": "^0.3",
         "phpmd/phpmd": "^2.13",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5 || ^10.0",
         "spatie/laravel-ray": "^1.26",
         "squizlabs/php_codesniffer": "^3.7"
     },

--- a/src/HookJobProcess.php
+++ b/src/HookJobProcess.php
@@ -30,33 +30,16 @@ class HookJobProcess
     public function send(): void
     {
         foreach ($this->search as $webhookClient) {
-            switch ($webhookClient->data_option) {
-                case 'summary':
-                    WebhookCall::create()
-                        ->url($webhookClient->url)
-                        ->maximumTries(3)
-                        ->meta(['webhookClient' => $webhookClient->id])
-                        ->doNotSign()
-                        ->useHttpVerb($webhookClient->method)
-                        ->verifySsl($webhookClient->verifySsl)
-                        ->withHeaders($webhookClient->header)
-                        ->payload([$this->payloadSummary($this->model, $this->event, $this->module)])
-                        ->dispatchSync();
-
-                    break;
-                case 'all':
-                    WebhookCall::create()
-                         ->url($webhookClient->url)
-                         ->maximumTries(3)
-                         ->meta(['webhookClient' => $webhookClient->id])
-                         ->doNotSign()
-                         ->useHttpVerb($webhookClient->method)
-                         ->verifySsl($webhookClient->verifySsl)
-                         ->withHeaders($webhookClient->header)
-                         ->payload([$this->payloadAll($this->model, $this->event, $this->module)])
-                         ->dispatchSync();
-                    break;
-            }
+            WebhookCall::create()
+                ->url($webhookClient->url)
+                ->maximumTries(3)
+                ->meta(['webhookClient' => $webhookClient->id])
+                ->doNotSign()
+                ->useHttpVerb($webhookClient->method)
+                ->verifySsl($webhookClient->verifySsl)
+                ->withHeaders($webhookClient->header)
+                ->payload([$this->payload($this->model, $this->event, $this->module,$webhookClient->data_option)])
+                ->dispatchSync();
         }
     }
 }

--- a/src/Pages/Webhooks.php
+++ b/src/Pages/Webhooks.php
@@ -107,11 +107,13 @@ class Webhooks extends Page implements HasTable
                     [
                         'all' => 'All Model Data',
                         'summary' => 'Summary',
+                        'custom' => 'Custom',
                     ]
                 )->descriptions(
                     [
                         'all' => 'All Data of the event triggered',
                         'summary' => 'Push only the ID if the record that trigger an event and its timestamp',
+                        'custom' => 'Only data defined on model`s toWebhookPayload method',
                     ]
                 )->columns(2)->required(),
                 CheckboxList::make('events')
@@ -154,11 +156,13 @@ class Webhooks extends Page implements HasTable
                     [
                         'all' => 'All Model Data',
                         'summary' => 'Summary',
+                        'custom' => 'Custom',
                     ]
                 )->descriptions(
                     [
                         'all' => 'All Data of the event triggered',
                         'summary' => 'Push only the ID if the record that trigger an event and its timestamp',
+                        'custom' => 'Only data defined on model`s toWebhookPayload method',
                     ]
                 )->columns(2)->required(),
                 CheckboxList::make('events')

--- a/src/Traits/helper.php
+++ b/src/Traits/helper.php
@@ -19,21 +19,13 @@ trait helper
         return $models;
     }
 
-    public function payloadAll(Model $model, $event, $module): object|array
+    public function payload(Model $model, $event, $module, $dataOption = 'summary'): object|array
     {
         return ApiResponseBuilder::create()
-                ->setModelData($model)
-                ->setEvent($event)
-                ->setModule($module)
-                ->generate();
-    }
-
-    public function payloadSummary(Model $model, $event, $module): object|array
-    {
-        return ApiResponseBuilder::create()
-            ->setSummaryModelData($model)
-            ->setEvent($event)
-            ->setModule($module)
-            ->generate();
+                                 ->setModel($model)
+                                 ->setDataOption($dataOption)
+                                 ->setEvent($event)
+                                 ->setModule($module)
+                                 ->generate();
     }
 }


### PR DESCRIPTION
Hey there,

I'm excited to share my pull request with you! I've made some changes to our package to add support for Laravel 10. Previously, it only supported Laravel 9, I've also added a new feature that allows for custom payloads.

This means that users can now create and send payloads with their own custom data, giving them even more flexibility and control over their requests. I believe this will be a valuable addition to our package, and I'm excited to see how users will make use of it.

I hope you find these changes useful, and I'm looking forward to hearing your feedback.