### PR TITLE
Add pages configurable

### DIFF
--- a/config/filament-webhook-server.php
+++ b/config/filament-webhook-server.php
@@ -1,5 +1,8 @@
 <?php
 
+use Marjose123\FilamentWebhookServer\Pages\WebhookHistory;
+use Marjose123\FilamentWebhookServer\Pages\Webhooks;
+
 return [
     /*
      *  Models that you want to be part of the webhooks options
@@ -13,4 +16,8 @@ return [
     'webhook' => [
         'keep_history' => false,
     ],
+    'pages' => [
+        Webhooks::class,
+        WebhookHistory::class,
+    ]
 ];

--- a/src/FilamentWebhookServerServiceProvider.php
+++ b/src/FilamentWebhookServerServiceProvider.php
@@ -5,8 +5,6 @@ namespace Marjose123\FilamentWebhookServer;
 use Filament\PluginServiceProvider;
 use Illuminate\Database\Eloquent\Model;
 use Marjose123\FilamentWebhookServer\Observers\ModelObserver;
-use Marjose123\FilamentWebhookServer\Pages\WebhookHistory;
-use Marjose123\FilamentWebhookServer\Pages\Webhooks;
 use Spatie\LaravelPackageTools\Exceptions\InvalidPackage;
 use Spatie\LaravelPackageTools\Package;
 
@@ -18,10 +16,10 @@ class FilamentWebhookServerServiceProvider extends PluginServiceProvider
         // CustomResource::class,
     ];
 
-    protected array $pages = [
-        Webhooks::class,
-        WebhookHistory::class,
-    ];
+    public function getPages(): array
+    {
+        return config('filament-webhook-server.pages');
+    }
 
     protected array $widgets = [
         // CustomWidget::class,


### PR DESCRIPTION
Sometimes I need to add a visualization policy or change some behavior. Perhaps this is the best way to make this part of the code extensible. I've seen this approach in other Filament plugins. Currently, I need to add a page trait from the Filament Shield plugin. This way, I'll be able to extend its class and change the implementation in the config.